### PR TITLE
Fix missing dependency handling in two cases

### DIFF
--- a/packetweaver/abilities/osi/phy_l1/save_pcap.py
+++ b/packetweaver/abilities/osi/phy_l1/save_pcap.py
@@ -1,8 +1,12 @@
 # coding: utf8
 import os
-import scapy.layers.l2
-import scapy.utils
 import packetweaver.core.ns as ns
+try:
+    import scapy.layers.l2
+    import scapy.utils
+    HAS_SCAPY = True
+except ImportError:
+    HAS_SCAPY = False
 
 
 class Ability(ns.ThreadedAbilityBase):
@@ -36,3 +40,11 @@ class Ability(ns.ThreadedAbilityBase):
             pass
 
         pcapwr.close()
+
+    @classmethod
+    def check_preconditions(cls, module_factory):
+        l = []
+        if not HAS_SCAPY:
+            l.append('Scapy support missing or broken. Please install it or proceed to an update.')
+        l += super(Ability, cls).check_preconditions(module_factory)
+        return l

--- a/packetweaver/core/models/modules/module_option.py
+++ b/packetweaver/core/models/modules/module_option.py
@@ -196,10 +196,7 @@ class PrefixOpt(ModuleOption):
         raise StopIteration()
 
     def is_valid(self, v):
-        return (
-            ((v is None or v == 'None') and self.is_optional())
-            or (ipaddr_mgmt.is_a_valid_prefix(v) and not ipaddr_mgmt.is_a_valid_ip_address(v))
-        )
+        return ((v is None or v == 'None') and self.is_optional()) or (ipaddr_mgmt.is_a_valid_prefix(v))
 
     def generate_one_value(self, v):
         return self.iterate_over_a_prefix(v)

--- a/pw-pkg-sstic/abilities/iterping.py
+++ b/pw-pkg-sstic/abilities/iterping.py
@@ -1,6 +1,15 @@
 # coding: utf8
 import packetweaver.core.ns as ns
-import subprocess
+try:
+    import ipaddress
+    HAS_NET_LIB = True
+except ImportError:
+    try:
+        import netaddr
+        HAS_NET_LIB = True
+    except ImportError:
+        HAS_NET_LIB = False
+
 
 class Ability(ns.AbilityBase):
     _info = ns.AbilityInfo(
@@ -20,3 +29,11 @@ class Ability(ns.AbilityBase):
                 self.get_dependency('ping', ip_dst=target_ip).start()
         except StopIteration:
             pass
+
+    @classmethod
+    def check_preconditions(cls, module_factory):
+        l = []
+        if not HAS_NET_LIB:
+            l.append('Python ipaddress or netaddr is required to run this ability. Please install one of them.')
+        l += super(Ability, cls).check_preconditions(module_factory)
+        return l


### PR DESCRIPTION
Scapy and ipaddress/netaddr were implicit dependencies for save_pcap and iterping abilities